### PR TITLE
Revert "ci: use YAML anchor to deduplicate workflow trigger paths (#27)"

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main
-    paths: &paths
+
+    paths:
       - '.github/workflows/**'
       - 'Cargo**'
       - 'src/**/*.rs'
@@ -12,7 +13,6 @@ on:
   pull_request:
     branches:
       - main
-    paths: *paths
 
 jobs:
   build-and-test:


### PR DESCRIPTION
This reverts commit 9944fd7e009137f1d2f15d6797670a0a18939fd7.