### PR TITLE
Clean up cache and logger APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Common utilities for Rust Lambdas
 
 ### Logging (`set_up_logger`)
 
-Configures structured logging via `fern` with UTC timestamps in the format `YYYY-MM-DDTHH:MM:SS.mmmZ`. Accepts a `Verbosity` level (Info / Debug / Trace) and applies it to the app and calling module, while keeping other crates at `Warn`. Logs the rustc version (captured at build time via `build.rs`) at `info` once configured.
+Configures structured logging via `fern` with UTC timestamps in the format `YYYY-MM-DDTHH:MM:SS.mmmZ`. Accepts `impl Into<Verbosity>` (Info / Debug / Trace) and applies it to the app and calling module, while keeping other crates at `Warn`. Logs the rustc version (captured at build time via `build.rs`) at `info` once configured.
 
 `Verbosity` converts from `bool` (false → Info, true → Debug) or `u8` (0 → Info, 1 → Debug, 2+ → Trace).
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -3,9 +3,9 @@ use chrono::Utc;
 use log::debug;
 use std::env;
 use std::future::Future;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
-use tokio::fs::{self, OpenOptions};
-use tokio::io::AsyncWriteExt;
+use tokio::fs;
 
 /// Whether [`try_cached_query`] should consult and populate the on-disk cache.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -64,13 +64,17 @@ where
 }
 
 async fn try_cached(mode: CacheMode, cache_path: &Path) -> Result<Option<String>> {
-    if mode.is_enabled() && cache_path.exists() {
-        debug!("Reading cache file: {cache_path:?}");
-        Ok(Some(fs::read_to_string(cache_path).await.with_context(
-            || format!("Failed to read cache file: {cache_path:?}"),
-        )?))
-    } else {
-        Ok(None)
+    if !mode.is_enabled() {
+        return Ok(None);
+    }
+
+    match fs::read_to_string(cache_path).await {
+        Ok(cached) => {
+            debug!("Read cache file: {cache_path:?}");
+            Ok(Some(cached))
+        }
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e).with_context(|| format!("Failed to read cache file: {cache_path:?}")),
     }
 }
 
@@ -78,17 +82,9 @@ async fn try_write_cache(mode: CacheMode, cache_path: &Path, response: &str) -> 
     if mode.is_enabled() {
         debug!("Writing response to cache file: {cache_path:?}");
 
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(cache_path)
+        fs::write(cache_path, response)
             .await
-            .with_context(|| format!("Failed to create or open cache file: {cache_path:?}"))?;
-
-        file.write_all(response.as_bytes())
-            .await
-            .with_context(|| format!("Failed to write data to cache file: {cache_path:?}"))?;
+            .with_context(|| format!("Failed to write cache file: {cache_path:?}"))?;
     }
 
     Ok(())

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -5,5 +5,5 @@ pub async fn init(
     calling_module: &'static str,
     verbosity: impl Into<Verbosity>,
 ) -> anyhow::Result<()> {
-    set_up_logger(app_name, calling_module, verbosity.into())
+    set_up_logger(app_name, calling_module, verbosity)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,9 +48,9 @@ impl From<Verbosity> for LevelFilter {
 pub fn set_up_logger(
     app_name: &'static str,
     calling_module: &'static str,
-    verbosity: Verbosity,
+    verbosity: impl Into<Verbosity>,
 ) -> Result<()> {
-    let level = verbosity.into();
+    let level = LevelFilter::from(verbosity.into());
 
     let _ = fern::Dispatch::new()
         .format(|out, message, record| {
@@ -65,7 +65,7 @@ pub fn set_up_logger(
         .level(LevelFilter::Warn)
         .level_for(app_name, level)
         .level_for(calling_module, level)
-        .level_for("jluszcz_rust_utils", level)
+        .level_for(env!("CARGO_CRATE_NAME"), level)
         .chain(std::io::stdout())
         .apply();
 


### PR DESCRIPTION
- try_cached: read the cache file directly and treat NotFound as a miss, removing the blocking exists() check and the check-then-read race
- try_write_cache: replace OpenOptions + write_all with fs::write
- set_up_logger: accept impl Into<Verbosity> to match lambda::init, and use CARGO_CRATE_NAME instead of a hardcoded crate name