### PR TITLE
chore: rename CI workflow to ci.yml and normalize build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: CI
 
 on:
   push:
@@ -15,7 +15,8 @@ on:
       - main
 
 jobs:
-  build-and-test:
+  build:
+    name: Build, Test & Lint
     runs-on: ubuntu-24.04-arm
 
     env:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Common utilities for Rust Lambdas
 
 ## Status
 
-[![Status Badge](https://github.com/jluszcz/rust-utils/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/jluszcz/rust-utils/actions/workflows/build-and-test.yml)
+[![Status Badge](https://github.com/jluszcz/rust-utils/actions/workflows/ci.yml/badge.svg)](https://github.com/jluszcz/rust-utils/actions/workflows/ci.yml)
 
 ## Utilities
 


### PR DESCRIPTION
Rename build-and-test.yml to ci.yml and rename the build-and-test job to build (with an explicit "Build, Test & Lint" name) so the check name is consistent across repos.