### PR TITLE
chore(ci): lint test code and check formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get install -y musl-tools
           rustup target add ${{ env.BUILD_TARGET }}
           rustup update
-          rustup component add clippy
+          rustup component add clippy rustfmt
 
       - name: Dump Toolchain Info
         run: |
@@ -44,5 +44,8 @@ jobs:
       - name: Test
         run: cargo test --target ${{ env.BUILD_TARGET }} --all-features
 
+      - name: Format
+        run: cargo fmt --check
+
       - name: Lint
-        run: cargo clippy --target ${{ env.BUILD_TARGET }} --all-features -- -D warnings
+        run: cargo clippy --target ${{ env.BUILD_TARGET }} --all-targets --all-features -- -D warnings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `cargo build` - Build the library
 - `cargo test` - Run all tests
 - `cargo fmt --check` - Check formatting (same as CI)
-- `cargo clippy --all-targets --all-features -- -D warnings` - Run linter with warnings as errors (same as CI)
+- `cargo clippy --all-targets --all-features -- -D warnings` - Run linter with warnings as errors
 
 ### Production Build
 - `cargo build --target aarch64-unknown-linux-musl --all-features` - Build for ARM64 Linux (Lambda target)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,12 +7,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Build and Test
 - `cargo build` - Build the library
 - `cargo test` - Run all tests
-- `cargo clippy -- -D warnings` - Run linter with warnings as errors
+- `cargo fmt --check` - Check formatting (same as CI)
+- `cargo clippy --all-targets --all-features -- -D warnings` - Run linter with warnings as errors (same as CI)
 
 ### Production Build
-- `cargo build --target aarch64-unknown-linux-musl` - Build for ARM64 Linux (Lambda target)
-- `cargo test --target aarch64-unknown-linux-musl` - Test on target platform
-- `cargo clippy --target aarch64-unknown-linux-musl -- -D warnings` - Lint for target platform
+- `cargo build --target aarch64-unknown-linux-musl --all-features` - Build for ARM64 Linux (Lambda target)
+- `cargo test --target aarch64-unknown-linux-musl --all-features` - Test on target platform
+- `cargo clippy --target aarch64-unknown-linux-musl --all-targets --all-features -- -D warnings` - Lint for target platform
 
 ## Architecture
 


### PR DESCRIPTION
Add a Format (cargo fmt --check) CI step before Lint, lint test code (--all-targets), and sync CLAUDE.md commands with CI.