### PR TITLE
ci: report claude-review check on skipped dependency PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,6 @@ on:
 
 jobs:
   claude-review:
-    # Skip dependency PRs (same rules as dependency auto-merge)
-    if: >
-      github.event.pull_request.user.login != 'dependabot[bot]' &&
-      !(github.event.pull_request.user.login == 'jluszcz' && startsWith(github.event.pull_request.head.ref, 'Deps-'))
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -32,6 +27,10 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
+        # Skip dependency PRs; job still reports success so the required check passes
+        if: >
+          github.event.pull_request.user.login != 'dependabot[bot]' &&
+          !(github.event.pull_request.user.login == 'jluszcz' && startsWith(github.event.pull_request.head.ref, 'Deps-'))
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Moves the dependabot/`Deps-` skip from the job level to a step-level `if:` on
the Claude review step, so the `claude-review` job always completes and reports
a passing check (dependency PRs skip only the Claude step).

This is a prerequisite for making `claude-review` a **required status check** in
branch protection: with the old job-level skip, dependency PRs would deadlock on
a check that never reports.

No behavior change for normal PRs; dependency PRs still skip the review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
