### PR TITLE
Use shared rust-ci reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,40 +18,9 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build, Test & Lint
-    runs-on: ubuntu-24.04-arm
-
-    env:
-      BUILD_TARGET: aarch64-unknown-linux-musl
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Update and Configure Rust
-        run: |
-          sudo apt-get install -y musl-tools
-          rustup target add ${{ env.BUILD_TARGET }}
-          rustup update
-          rustup component add clippy rustfmt
-
-      - name: Dump Toolchain Info
-        run: |
-          cargo --version --verbose
-          rustc --version
-          cargo clippy --version
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build
-        run: cargo build --target ${{ env.BUILD_TARGET }} --all-features
-
-      - name: Test
-        run: cargo test --target ${{ env.BUILD_TARGET }} --all-features
-
-      - name: Format
-        run: cargo fmt --check
-
-      - name: Lint
-        run: cargo clippy --target ${{ env.BUILD_TARGET }} --all-targets --all-features -- -D warnings
+  ci:
+    uses: jluszcz/github-utils/.github/workflows/rust-ci.yml@v1
+    with:
+      runs-on: ubuntu-24.04-arm
+      target: aarch64-unknown-linux-musl
+      all-features: true


### PR DESCRIPTION
Replaces the inlined Rust CI job with a call to the shared reusable workflow `jluszcz/github-utils/.github/workflows/rust-ci.yml@v1` (exercises `runs-on`, `target`, and `all-features` inputs). No behavior change — same build/test/fmt/clippy on `ubuntu-24.04-arm` with the musl target and `--all-features`.

The required status check name changes from `Build, Test & Lint` to `ci / Build, Test & Lint`; the `main` ruleset is updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)