### PR TITLE
chore(deps): pin 0.x dependencies to their minor version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `cargo clippy --all-targets --all-features -- -D warnings` - Run linter with warnings as errors
 
 ### Production Build
+
+These are the commands CI runs. The `aarch64-unknown-linux-musl` target is **not** installed locally by default and
+nothing in this repo (no `rust-toolchain.toml`, no `.cargo/config.toml`) declares it — run `rustup target add
+aarch64-unknown-linux-musl` first if you need to reproduce a CI failure locally.
+
 - `cargo build --target aarch64-unknown-linux-musl --all-features` - Build for ARM64 Linux (Lambda target)
 - `cargo test --target aarch64-unknown-linux-musl --all-features` - Test on target platform
 - `cargo clippy --target aarch64-unknown-linux-musl --all-targets --all-features -- -D warnings` - Lint for target platform
@@ -31,8 +36,16 @@ This is a Rust utilities library (`jluszcz_rust_utils`) designed for AWS Lambda 
 
 ### Build System
 - Uses `build.rs` to capture rustc version at build time via `RUSTC_VERSION` environment variable
-- Configured for `aarch64-unknown-linux-musl` target (ARM64 Lambda runtime)
+- CI builds against `aarch64-unknown-linux-musl` (ARM64 Lambda runtime); the target is selected by the CI workflow,
+  not by anything checked into this repo
+
+### Dependency Versioning
+- Pin 0.x dependencies to their **minor** version (`chrono = "0.4"`, not `chrono = "0"`). For 0.x crates the minor
+  version is the breaking axis, so a bare `"0"` resolves to `<1.0.0` and lets breaking releases through silently.
+- Five sibling repos consume this crate as an unpinned git dependency, so a break here fans out to all of them.
 
 ### Testing
 - Unit tests in `cache.rs` and `query.rs` modules
-- CI runs on ubuntu-24.04-arm with full build/test/lint pipeline
+- CI is a thin caller of `jluszcz/github-utils/.github/workflows/rust-ci.yml@v1` (`.github/workflows/ci.yml`), which
+  runs build, test, `cargo fmt --check`, and `cargo clippy -- -D warnings` on `ubuntu-24.04-arm` with `--all-features`.
+  The steps live in that shared workflow, not in this repo.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,18 +8,18 @@ license = "MIT"
 repository = "https://github.com/jluszcz/rust-utils"
 
 [build-dependencies]
-rustc_version = "0"
+rustc_version = "0.4"
 
 [features]
 query = ["dep:backon", "dep:reqwest", "dep:serde", "dep:tokio"]
 
 [dependencies]
 anyhow = "1"
-chrono = "0"
-fern = "0"
-log = "0"
+chrono = "0.4"
+fern = "0.7"
+log = "0.4"
 backon  = { version = "1",    optional = true }
-reqwest = { version = "0", features = ["gzip", "json", "query"], optional = true }
+reqwest = { version = "0.13", features = ["gzip", "json", "query"], optional = true }
 serde   = { version = "1",    features = ["derive"], optional = true }
 tokio   = { version = "1",    features = ["fs"], optional = true }
 


### PR DESCRIPTION
For 0.x crates the minor version is the breaking axis, so a bare `"0"` requirement resolves to `<1.0.0` and lets breaking releases through as if they were compatible. This had already happened silently — the lockfile carries `reqwest 0.13.4` and `fern 0.7.1`.

Pins match the versions already in `Cargo.lock`, so dependency resolution is unchanged (`git diff Cargo.lock` is empty). What changes is that a future `0.4 → 0.5` bump now shows up as an explicit Dependabot PR instead of being applied silently.

Five sibling repos consume this crate as an unpinned git dependency, so tightening it here stops the fan-out.

Also corrects `CLAUDE.md`, which described the `aarch64-unknown-linux-musl` target as repo configuration (nothing here declares it) and the build/test/lint pipeline as local when both live in the shared `rust-ci` reusable workflow.

## Verification

- `cargo fmt --check` — pass
- `cargo clippy --all-targets --all-features -- -D warnings` — pass
- `cargo test --all-features` — 7/7 pass
- `Cargo.lock` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)