### PR TITLE
docs: document the public API and enforce it with missing_docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,14 @@ This is a Rust utilities library (`jluszcz_rust_utils`) designed for AWS Lambda 
 - CI builds against `aarch64-unknown-linux-musl` (ARM64 Lambda runtime); the target is selected by the CI workflow,
   not by anything checked into this repo
 
+### Documentation
+- `src/lib.rs` sets `#![warn(missing_docs)]`, and CI lints with `-D warnings`, so **every new public item needs a doc
+  comment or the build fails**. This is deliberate: the crate is consumed by five sibling repos whose authors read
+  rustdoc rather than the source.
+- Document the *why* a caller can't infer: `set_up_logger` caps dependencies at `Warn` so verbosity doesn't bury the
+  application's own output; `lambda::init` is `async` and fallible for future headroom rather than present need.
+  `cache.rs` and `query.rs` were already written this way and are the template.
+
 ### Dependency Versioning
 - Pin 0.x dependencies to their **minor** version (`chrono = "0.4"`, not `chrono = "0"`). For 0.x crates the minor
   version is the breaking axis, so a bare `"0"` resolves to `<1.0.0` and lets breaking releases through silently.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,3 +1,9 @@
+//! An on-disk cache for query responses, keyed by date.
+//!
+//! Intended for data that changes at most daily and is expensive or rate-limited
+//! to fetch — the cache file lives in the system temp directory, so it survives
+//! repeated runs on one machine but nothing more.
+
 use anyhow::{Context, Result};
 use chrono::Utc;
 use log::debug;
@@ -10,7 +16,10 @@ use tokio::fs;
 /// Whether [`try_cached_query`] should consult and populate the on-disk cache.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum CacheMode {
+    /// Read from the cache when it holds today's data, and write to it after a
+    /// successful query.
     Enabled,
+    /// Always query, and leave the cache untouched.
     Disabled,
 }
 

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -1,5 +1,13 @@
+//! Entry-point helper for AWS Lambda binaries.
+
 use crate::{Verbosity, set_up_logger};
 
+/// Prepares a Lambda invocation: currently just logging setup.
+///
+/// Call this once at the top of `main`, before `lambda_runtime::run`. It is
+/// `async` and returns a `Result` because Lambda initialization has needed both
+/// before and may again — the handful of binaries that call it are easier to
+/// leave as-is than to churn every time this crate's needs change.
 pub async fn init(
     app_name: &'static str,
     calling_module: &'static str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+//! Small utilities shared across personal Rust projects: logging setup, an
+//! AWS Lambda entry point, and (behind the `query` feature) an HTTP query
+//! helper with an on-disk response cache.
+#![warn(missing_docs)]
+
 use anyhow::Result;
 use chrono::Utc;
 use log::{LevelFilter, info};
@@ -12,10 +17,18 @@ pub mod cache;
 
 pub(crate) const RUSTC_VERSION: &str = env!("RUSTC_VERSION");
 
+/// How much the calling application should log.
+///
+/// This maps onto [`log::LevelFilter`], but only over the three levels worth
+/// exposing as a user-facing switch. Construct it from a `-v` count via
+/// [`From<u8>`](#impl-From<u8>-for-Verbosity) or from a boolean flag.
 #[derive(Debug, Copy, Clone)]
 pub enum Verbosity {
+    /// Everything, including per-request detail.
     Trace,
+    /// Diagnostics useful while developing.
     Debug,
+    /// The default: significant events only.
     Info,
 }
 
@@ -45,6 +58,21 @@ impl From<Verbosity> for LevelFilter {
     }
 }
 
+/// Installs a global logger that prints timestamped lines to stdout.
+///
+/// The level applies to `app_name`, `calling_module`, and this crate; everything
+/// else — dependencies, most importantly — is capped at `Warn`, so raising
+/// verbosity does not bury the application's own output in library chatter.
+/// `calling_module` is normally `module_path!()` from the caller.
+///
+/// Calling this more than once is harmless: the second and later calls are
+/// ignored rather than failing, so tests and Lambda cold starts can both call it
+/// freely.
+///
+/// # Errors
+///
+/// Returns `Ok(())` today; the signature is fallible so a future implementation
+/// can report a failure without breaking callers.
 pub fn set_up_logger(
     app_name: &'static str,
     calling_module: &'static str,

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,3 +1,6 @@
+//! HTTP query helpers: a shared client, retries with exponential backoff, and
+//! typed JSON responses.
+
 use anyhow::{Context, Result};
 use backon::{ExponentialBuilder, Retryable};
 use log::trace;


### PR DESCRIPTION
Closes finding 22 from the portfolio review.

Compiling with `#![warn(missing_docs)]` produced **13 warnings** across the default-feature API — `Verbosity` and all three of its variants, `set_up_logger`, `lambda::init`, and the `query`/`cache` module headers had no documentation at all. This crate is consumed by five sibling repos whose authors read rustdoc rather than this source.

The attribute is now committed, so **CI's `clippy -D warnings` fails on any undocumented public item** rather than relying on someone noticing.

`cache.rs` and `query.rs` were already documented well and set the tone: the comments explain what a caller cannot infer from the signature.

- `set_up_logger` caps everything except the app, the calling module, and this crate at `Warn` — so raising verbosity surfaces the application's own output instead of burying it in dependency chatter. It also swallows repeat calls, which is why tests and Lambda cold starts can both call it.
- `lambda::init` is `async` and returns `Result` for headroom, not present need. Worth saying, since it currently just forwards to `set_up_logger` and reads like an accident.
- `CacheMode`'s variants describe what each does to the cache file, not just that one is on and one is off.

### Verification

`cargo build` and `cargo build --all-features` — **0 missing-docs warnings**, down from 13. `cargo doc --all-features --no-deps` builds clean, `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` pass, and `cargo test --all-features` is green (7).

CLAUDE.md records the convention and the reason, so the next public item gets documented rather than the lint being switched off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)